### PR TITLE
Save the best model

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -72,7 +72,7 @@ class Learner():
     def save_cycle(self, name, cycle): self.save(f'{name}_cyc_{cycle}')
     def load_cycle(self, name, cycle): self.load(f'{name}_cyc_{cycle}')
 
-    def fit_gen(self, model, data, layer_opt, n_cycle, cycle_len=None, cycle_mult=1, cycle_save_name=None,
+    def fit_gen(self, model, data, layer_opt, n_cycle, cycle_len=None, cycle_mult=1, cycle_save_name=None, best_save_name=None,
                 use_clr=None, metrics=None, callbacks=None, use_wd_sched=False, norm_wds=False, wds_sched_mult=None, **kwargs):
 
         """Method does some preparation before finally delegating to the 'fit' method for
@@ -101,6 +101,8 @@ class Learner():
                 https://github.com/fastai/fastai/blob/master/courses/dl1/lesson1.ipynb
 
             cycle_save_name (str): use to save the weights at end of each cycle
+            
+            best_save_name (str): use to save weights of best model during training.
 
             metrics (function): some function for evaluating a desired metric. Eg. accuracy.
 
@@ -151,6 +153,10 @@ class Learner():
             self.sched = CosAnneal(layer_opt, cycle_batches, on_cycle_end=cycle_end, cycle_mult=cycle_mult)
         elif not self.sched: self.sched=LossRecorder(layer_opt)
         callbacks+=[self.sched]
+        
+        if best_save_name is not None:
+            callbacks+=[SaveBestModel(self, layer_opt, best_save_name)]
+            
         n_epoch = sum_geom(cycle_len if cycle_len else 1, cycle_mult, n_cycle)
         return fit(model, data, n_epoch, layer_opt.opt, self.crit,
             metrics=metrics, callbacks=callbacks, reg_fn=self.reg_fn, clip=self.clip, **kwargs)


### PR DESCRIPTION
Save the best model during training When we call 'fit' method to train a model, we usually set the attribute  'cycle_save_name' in order to save the weights of the model at the end of each cycle. But sometimes, a better performance is reached before the end  of a cycle, this arises when cycle_len > 1. So this feature allows to check  after each epoch if we have a better model and save it accordingly.